### PR TITLE
Use surface distance in surface spreading calculation

### DIFF
--- a/docs/notebooks/Estimating RSSNR from CReSIS MCoRDS data.ipynb
+++ b/docs/notebooks/Estimating RSSNR from CReSIS MCoRDS data.ipynb
@@ -345,7 +345,7 @@
     "\n",
     "    surface_sample_idx = np.array([np.argmin(np.abs(line['fast_time'] - x)) for x in line['surface_s']])\n",
     "    surface_pwr = np.array([line['pwr_db'][ft_idx, st_idx] for st_idx, ft_idx in enumerate(surface_sample_idx)])\n",
-    "    surface_spreading_db = 2 * 10 * np.log10(2 * line['ice_thickness_m'])\n",
+    "    surface_spreading_db = 2 * 10 * np.log10(2 * line['surface_m'])\n",
     "\n",
     "    fig, (ax, ax_req_snr) = plt.subplots(2, 1, figsize=(10, 6), sharex=True)\n",
     "\n",


### PR DESCRIPTION
Quick fix for the surface spreading factor! This PR switches from using the ice thickness to using the surface range for the surface spreading factor calculation.

<details>
<summary>(<i>Confusion about a factor of two - resolved!</i>)</summary>
One thing I'm not sure about is whether the factor of 2 inside the `log10` function should be there. Matsuoka et al 2012 ([DOI link](https://doi.org/10.1016/j.epsl.2012.10.018)) uses just the one-way distance inside the log, if I'm reading it right.

<img width="1052" height="863" alt="image" src="https://github.com/user-attachments/assets/1cdf9268-9817-40f6-8d82-b33e33482d90" />
</details>